### PR TITLE
Fix frontend authentication url

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,4 +1,6 @@
-VITE_YANDEX_CLIENT_ID=asdf
-PUBLIC_USER_API_BASE_URL=http://localhost:8080
-PUBLIC_AUTH_API_BASE_URL=http://localhost:8080
-PUBLIC_WISHLIST_API_BASE_URL=http://localhost:8081
+PUBLIC_AUTH_API_BASE_URL=https://api.wili.me
+PUBLIC_USER_API_BASE_URL=https://api.wili.me
+PUBLIC_WISHLIST_API_BASE_URL=https://api.wili.me/wishlists
+
+# Build-time only in Vite/SvelteKit
+VITE_YANDEX_CLIENT_ID=your_yandex_oauth_client_id

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -20,7 +20,7 @@ RUN chmod -R 755 node_modules/.bin
 
 # Accept build arguments and set as environment variables
 ARG PUBLIC_AUTH_API_BASE_URL=https://api.wili.me
-ARG PUBLIC_USER_API_BASE_URL=https://api.wili.me/users
+ARG PUBLIC_USER_API_BASE_URL=https://api.wili.me
 ARG PUBLIC_WISHLIST_API_BASE_URL=https://api.wili.me/wishlists
 ARG VITE_YANDEX_CLIENT_ID
 ENV PUBLIC_AUTH_API_BASE_URL=$PUBLIC_AUTH_API_BASE_URL

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -8,7 +8,7 @@ export const USER_KEY = 'wili_user';
 export const JUST_LOGGED_IN_KEY = 'wili_just_logged_in';
 
 // Prefer SvelteKit dynamic public env; fall back to Vite env at runtime
-const AUTH_API_BASE_URL = env.PUBLIC_AUTH_API_BASE_URL ?? (import.meta as any).env?.VITE_AUTH_API_BASE_URL ?? '';
+const AUTH_API_BASE_URL = env.PUBLIC_AUTH_API_BASE_URL ?? env.PUBLIC_API_BASE_URL ?? (import.meta as any).env?.VITE_AUTH_API_BASE_URL ?? 'https://api.wili.me';
 
 type AuthResponse = components['schemas']['AuthResponse'];
 

--- a/k8s/frontend.yaml
+++ b/k8s/frontend.yaml
@@ -6,6 +6,9 @@ metadata:
 data:
   NODE_ENV: "production"
   PUBLIC_API_BASE_URL: "https://api.wili.me"
+  PUBLIC_AUTH_API_BASE_URL: "https://api.wili.me"
+  PUBLIC_USER_API_BASE_URL: "https://api.wili.me"
+  PUBLIC_WISHLIST_API_BASE_URL: "https://api.wili.me/wishlists"
 
 ---
 apiVersion: apps/v1
@@ -39,6 +42,21 @@ spec:
             configMapKeyRef:
               name: frontend-config
               key: PUBLIC_API_BASE_URL
+        - name: PUBLIC_AUTH_API_BASE_URL
+          valueFrom:
+            configMapKeyRef:
+              name: frontend-config
+              key: PUBLIC_AUTH_API_BASE_URL
+        - name: PUBLIC_USER_API_BASE_URL
+          valueFrom:
+            configMapKeyRef:
+              name: frontend-config
+              key: PUBLIC_USER_API_BASE_URL
+        - name: PUBLIC_WISHLIST_API_BASE_URL
+          valueFrom:
+            configMapKeyRef:
+              name: frontend-config
+              key: PUBLIC_WISHLIST_API_BASE_URL
         # VITE_YANDEX_CLIENT_ID is now built into the image at build time
         resources:
           requests:


### PR DESCRIPTION
Fix frontend authentication URL to use `api.wili.me` instead of `wili.me`.

The frontend was falling back to an empty base URL for authentication, causing requests to be made relative to the current origin (`wili.me`) instead of the intended API endpoint (`api.wili.me`). This PR ensures correct API base URLs are used by adding robust fallbacks in the SvelteKit code and standardizing runtime environment variables in the Kubernetes deployment.

---
<a href="https://cursor.com/background-agent?bcId=bc-abd36b8f-b61f-4d4f-a9b6-ce9b6aa8ce99">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-abd36b8f-b61f-4d4f-a9b6-ce9b6aa8ce99">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

